### PR TITLE
  Move printer selection to admin dialog with localStorage persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,14 @@
 
 <dialog id="admin-dialog" aria-labelledby="admin-dialog-title">
     <h2 id="admin-dialog-title">Admin Actions</h2>
+    <label for="admin-printer-select" style="display: none">Printer</label>
+    <select id="admin-printer-select">
+        <option value="">Loading printers…</option>
+    </select>
     <button id="participant-labels">Print&nbsp;All&nbsp;Participants</button>
     <button id="test-printer-connection" class="feature-block">Test&nbsp;Printer&nbsp;Connection</button>
     <button id="print-client-qr">Print&nbsp;WebClient&nbsp;QR</button>
+    <hr/>
     <button id="close-admin">Close</button>
 </dialog>
 
@@ -24,12 +29,7 @@
     <div style="flex-direction: column">
         <img src="/jscc-og-image.png" alt="JSCC" style="width: 100%; max-width: 600px;" />
         <h1>Label Printer</h1>
-        <div class="feature-block">
-            <label for="printer-name">Select Printer</label>
-            <select id="printer-name" name="printerName">
-                <option value="">Loading printers…</option>
-            </select>
-        </div>
+        <input type="hidden" id="printer-name" name="printerName" style="padding: 0" />
         <div class="feature-block">
             <label for="file-upload">PNG to ZPL</label>
             <input type="file" id="file-upload" accept="image/png"/>

--- a/server/api/printers.ts
+++ b/server/api/printers.ts
@@ -1,13 +1,13 @@
 import {exec} from 'child_process';
 import type {FastifyReply, FastifyRequest} from 'fastify';
 
-function getInstalledPrinters(): Promise<string[]> {
+function getActivePrinters(): Promise<string[]> {
     return new Promise((resolve) => {
         exec('lpstat -p', (error, stdout) => {
             if (error || !stdout.trim()) return resolve([]);
             const printers = stdout
                 .split('\n')
-                .filter(line => line.startsWith('printer '))
+                .filter(line => line.startsWith('printer ') && /is (idle|processing)/.test(line))
                 .map(line => line.split(' ')[1]);
             resolve(printers);
         });
@@ -15,6 +15,6 @@ function getInstalledPrinters(): Promise<string[]> {
 }
 
 export async function printers(_request: FastifyRequest, reply: FastifyReply) {
-    const list = await getInstalledPrinters();
+    const list = await getActivePrinters();
     reply.send({printers: list});
 }

--- a/src/client/lib/formElement/form-element.ts
+++ b/src/client/lib/formElement/form-element.ts
@@ -1,4 +1,5 @@
 import {createJSCCLabel} from "../../templates/create-jscc-label.ts";
+import {PRINTER_STORAGE_KEY} from "../../../shared/constants.ts";
 
 const overlay = document.querySelector<HTMLDivElement>('#loading-overlay')!;
 const showLoading = () => { overlay.classList.add('visible'); document.body.setAttribute('aria-busy', 'true'); };
@@ -15,19 +16,48 @@ if (import.meta.env.DEV) {
     document.body.prepend(banner);
 }
 
-const printerSelect = document.querySelector<HTMLSelectElement>('#printer-name');
-if (printerSelect) {
-    fetch('/printers')
-        .then(r => r.json())
-        .then(({printers}: {printers: string[]}) => {
-            printerSelect.innerHTML = printers.length
-                ? printers.map(p => `<option value="${p}">${p}</option>`).join('')
-                : '<option value="">No printers found</option>';
-        })
-        .catch(() => {
-            printerSelect.innerHTML = '<option value="">Could not load printers</option>';
-        });
+
+const printerInput = document.querySelector<HTMLInputElement>('#printer-name');
+const adminPrinterSelect = document.querySelector<HTMLSelectElement>('#admin-printer-select');
+
+function setActivePrinter(name: string) {
+    if (printerInput) printerInput.value = name;
+    if (adminPrinterSelect) adminPrinterSelect.value = name;
+    if (name) {
+        localStorage.setItem(PRINTER_STORAGE_KEY, name);
+    } else {
+        localStorage.removeItem(PRINTER_STORAGE_KEY);
+    }
 }
+
+if (printerInput) {
+    const saved = localStorage.getItem(PRINTER_STORAGE_KEY);
+    if (saved) printerInput.value = saved;
+}
+
+if (adminPrinterSelect) {
+    adminPrinterSelect.addEventListener('change', () => {
+        setActivePrinter(adminPrinterSelect.value);
+    });
+}
+
+fetch('/printers')
+    .then(r => r.json())
+    .then(({printers}: {printers: string[]}) => {
+        const saved = localStorage.getItem(PRINTER_STORAGE_KEY);
+        if (adminPrinterSelect) {
+            const placeholder = '<option value="">Select a printer…</option>';
+            adminPrinterSelect.innerHTML = placeholder + printers.map(p => `<option value="${p}">${p}</option>`).join('');
+        }
+        if (printers.length) {
+            if (saved && printers.includes(saved)) setActivePrinter(saved);
+        } else {
+            setActivePrinter('');
+        }
+    })
+    .catch(() => {
+        if (adminPrinterSelect) adminPrinterSelect.innerHTML = '<option value="">Could not load printers</option>';
+    });
 
 const adminDialog = document.querySelector<HTMLDialogElement>('#admin-dialog');
 document.querySelector('#open-admin')?.addEventListener('click', () => adminDialog?.showModal());
@@ -43,7 +73,7 @@ if (participantLabelsButton) {
         adminDialog?.close();
         const printerName = String(
             import.meta.env.VITE_PRINTER_NAME ||
-            document.querySelector<HTMLSelectElement>('#printer-name')?.value
+            document.querySelector<HTMLInputElement>('#printer-name')?.value
         );
         showLoading();
         try {
@@ -74,7 +104,7 @@ if (printQrButton) {
         adminDialog?.close();
         const printerName = String(
             import.meta.env.VITE_PRINTER_NAME ||
-            document.querySelector<HTMLSelectElement>('#printer-name')?.value
+            document.querySelector<HTMLInputElement>('#printer-name')?.value
         );
         showLoading();
         try {

--- a/src/client/style.css
+++ b/src/client/style.css
@@ -194,6 +194,16 @@ summary {
     text-overflow: ellipsis;
 }
 
+#admin-dialog select {
+    margin-bottom: 0;
+}
+
+#admin-dialog hr {
+    border: none;
+    border-top: 2px solid color-mix(in srgb, var(--accent) 25%, transparent);
+    margin: 0.25rem 0;
+}
+
 #admin-dialog::backdrop {
     background: var(--overlay);
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,1 +1,2 @@
 export const JSCC_YEAR = 26;
+export const PRINTER_STORAGE_KEY = 'jscc-selected-printer';


### PR DESCRIPTION
  - Filter /printers endpoint to only return idle/processing printers
  - Replace form select with a hidden input; printer name still submits with the form
  - Add printer select to admin dialog with a placeholder "Select a printer…" option
  - Persist selected printer to localStorage (PRINTER_STORAGE_KEY) on change; clear it when no active printers or user deselects
  - Restore saved printer across page loads if still in the active list
  - Add accent-tinted hr and fix select margin-bottom in admin dialog